### PR TITLE
docs: add README for internal package directory

### DIFF
--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,14 @@
+# Internal Package
+
+This directory contains the internal implementation packages for gorl (Go Rate Limiter).
+
+## Structure
+
+- `config/` - Configuration management for the rate limiter
+- `limiter/` - Core rate limiting implementation
+- `stats/` - Statistics collection and reporting
+- `tester/` - Testing utilities and load testing tools
+
+## Usage
+
+These packages are internal to the gorl application and should not be imported by external packages.


### PR DESCRIPTION
Add documentation explaining the purpose and structure of the internal package directory to improve code organization clarity.

🤖 Generated with [Claude Code](https://claude.ai/code)